### PR TITLE
Newtonsoft.Json can't deserialize objects

### DIFF
--- a/Analytics/Model/Alias.cs
+++ b/Analytics/Model/Alias.cs
@@ -14,6 +14,7 @@ namespace Segment.Model
 		[JsonProperty(PropertyName = "userId")]
 		private string UserId { get; set; }
 		
+        [JsonConstructor]
 		internal Alias(string previousId, string userId, Options options)
 			: base("alias", options)
 		{

--- a/Analytics/Model/Group.cs
+++ b/Analytics/Model/Group.cs
@@ -17,6 +17,7 @@ namespace Segment.Model
 		[JsonProperty(PropertyName = "traits")]
 		private Traits Traits { get; set; }
 
+        [JsonConstructor]
 		internal Group(string userId, 
 					   string groupId,
 					   Traits traits, 

--- a/Analytics/Model/Identify.cs
+++ b/Analytics/Model/Identify.cs
@@ -14,6 +14,7 @@ namespace Segment.Model
         [JsonProperty(PropertyName = "traits")]
 		public Traits Traits { get; set; }
 
+        [JsonConstructor]
         internal Identify(string userId,
 		                  Traits traits, 
 						  Options options)

--- a/Analytics/Model/Page.cs
+++ b/Analytics/Model/Page.cs
@@ -20,6 +20,7 @@ namespace Segment.Model
         [JsonProperty(PropertyName = "properties")]
         private Properties Properties { get; set; }
 
+        [JsonConstructor]
 		internal Page(string userId, 
 					  string name,
 					  string category,

--- a/Analytics/Model/Screen.cs
+++ b/Analytics/Model/Screen.cs
@@ -20,6 +20,7 @@ namespace Segment.Model
         [JsonProperty(PropertyName = "properties")]
         private Properties Properties { get; set; }
 
+        [JsonConstructor]
 		internal Screen(string userId, 
 						string name,
 					    string category,

--- a/Analytics/Model/Track.cs
+++ b/Analytics/Model/Track.cs
@@ -17,6 +17,7 @@ namespace Segment.Model
         [JsonProperty(PropertyName = "properties")]
         private Properties Properties { get; set; }
 
+        [JsonConstructor]
         internal Track(string userId, 
 		               string eventName,
             		   Properties properties, 


### PR DESCRIPTION
Add custom attribute JsonConstructor on constructor of classes that inhrerit BaseAction class, to Newtonsoft.Json can deserialize objects. 
Problem is classes that inhrerit BaseAction class is defined with internal operator on constructor.
