### PR TITLE
Correctly format custom timestamps.

### DIFF
--- a/Analytics.Xamarin.Pcl/Model/BaseAction.cs
+++ b/Analytics.Xamarin.Pcl/Model/BaseAction.cs
@@ -33,7 +33,7 @@ namespace Segment.Model
 			this.Type = type;
 			this.MessageId = Guid.NewGuid().ToString();
 			if (options.Timestamp.HasValue)
-				this.Timestamp = options.Timestamp.ToString();
+				this.Timestamp = options.Timestamp.ToString("o");
 			else
 				this.Timestamp = DateTime.Now.ToString("o");
 			this.Context = options.Context;


### PR DESCRIPTION
If a user sets the timestamp manually, we were simply calling
`ToString()` on it, which formats the time as per a local format,
instead of ISO 8601 timestamps.

This fix correctly converts custom timestamps in a local agnostic way.