### PR TITLE
Added AppVeyor build to automatically generate and publish Nuget package

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,6 @@
-﻿Analytics.Xamarin
+[![Build status](https://ci.appveyor.com/api/projects/status/nkigyelj5a3af6i4?svg=true)](https://ci.appveyor.com/project/dlbroadfoot/analytics-xamarin)
+
+Analytics.Xamarin
 =============
 
 Analytics.Xamarin is a [Xamarin](http://xamarin.com) portable class library [(PCL)](http://developer.xamarin.com/guides/cross-platform/application_fundamentals/pcl/) that makes the [Segment](https://segment.com) analytics API available for the following platforms:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,6 @@ deploy:
   - provider: NuGet
     server: http://packages.smokeball.com/nuget/smokeball/
     api_key:
-      secure: http://packages.smokeball.com/nuget/smokeball/
+      secure: Gb5neQyAROVe6WHeeLpjwGG0VPyVX8Oy/3eUUQBLpQA=
     on:
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+environment:
+  next_version: 3.0.2
+  is_pr: false
+
+only_commits:
+  files:
+    - src/
+    - nuget/*.nuspec
+image: Visual Studio 2017
+configuration: Release
+init:
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq "true")
+      {
+        Update-AppveyorBuild -Version "$env:APPVEYOR_REPO_TAG_NAME"
+      }
+      else
+      {
+        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER)
+        {
+          $env:is_pr = "false";
+          if ($env:APPVEYOR_REPO_BRANCH -ne "master")
+          {
+            Update-AppveyorBuild -Version "$($env:next_version)-$($env:APPVEYOR_REPO_BRANCH)-build$($env:APPVEYOR_BUILD_NUMBER)"
+          }
+          else
+          {
+            Update-AppveyorBuild -Version "$($env:next_version)-beta$($env:APPVEYOR_BUILD_NUMBER)"
+          }
+        }
+        else
+        {
+          $env:is_pr = "true";
+          Update-AppveyorBuild -Version "$($env:next_version)-pr$($env:APPVEYOR_PULL_REQUEST_NUMBER)-build$($env:APPVEYOR_BUILD_NUMBER)"
+        }
+      }
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+before_build:
+- cmd: nuget restore Analytics.Xamarin.sln
+build:
+  project: Analytics.Xamarin.sln
+  verbosity: minimal
+after_build:
+- cmd: nuget pack Analytics.Xamarin.nuspec -basepath "./" -version "%APPVEYOR_BUILD_VERSION%"
+artifacts:
+- path: '*.nupkg'
+
+deploy:
+  - provider: NuGet
+    server: http://packages.smokeball.com/nuget/smokeball/
+    api_key:
+      secure: Gb5neQyAROVe6WHeeLpjwGG0VPyVX8Oy/3eUUQBLpQA=
+    on:
+      branch: master
+      is_pr: false
+
+  - provider: NuGet
+    server: http://packages.smokeball.com/nuget/smokeball/
+    api_key:
+      secure: http://packages.smokeball.com/nuget/smokeball/
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@ environment:
   next_version: 3.0.2
   is_pr: false
 
-only_commits:
-  files:
-    - src/
-    - nuget/*.nuspec
 image: Visual Studio 2017
 configuration: Release
 init:


### PR DESCRIPTION
Added sample build file that works with AppVeyor (free build service for open source projects).

This works and currently pushes to our internal nuget feed, however with a minor tweak to the nuget config (remove server parameter), it can push to the public Nuget feed.

I'd prefer SegmentIO set up their own AppVeyor project in which case they'd just need to get encrypt their Nuget api key in AppVeyor and update this file, merge in the PR and they'd have a Nuget package on each build